### PR TITLE
fix autolink when code is not enabled for editor

### DIFF
--- a/packages/extension-link/src/helpers/autolink.ts
+++ b/packages/extension-link/src/helpers/autolink.ts
@@ -87,6 +87,7 @@ export function autolink(options: AutolinkOptions): Plugin {
             }))
             // ignore link inside code mark
             .filter(link => {
+              if (!newState.schema.marks.code) return true; // maybe code is not enabled for this editor
               return !newState.doc.rangeHasMark(
                 link.from,
                 link.to,


### PR DESCRIPTION
## Please describe your changes
fix autolink when code is not enabled for editor

## How did you accomplish your changes

When an editor does not have code extension enabled, `schema.marks.code` will be `undefined`, causing error when passed to `rangeHasMark` from autolink handler.
This pull request fix it by returning early from the filter function when `schema.marks.code` is not available.

## How have you tested your changes

Not yet, but will do it soon.

## How can we verify your changes

To reproduce the issue, just setup an editor without `extension-code` with autolink enabled, and then try to type a URL into the editor.
Apply this fix and retry, autolink should work then.

## Remarks

[add any additional remarks here]

## Checklist

- [x] The changes are not breaking the editor
- [ ] Added tests where possible
- [ ] Followed the guidelines
- [ ] Fixed linting issues

## Related issues

[add a link to the related issues here]
